### PR TITLE
Removing exposure to context for ser/de utilities.

### DIFF
--- a/src/elliptic/curves/traits.rs
+++ b/src/elliptic/curves/traits.rs
@@ -17,28 +17,25 @@
 use BigInt;
 use Point;
 
-pub trait CurveConstCodec {
-    fn get_base_point() -> Point;
+/// Secret Key Codec: BigInt <> SecretKey
+pub trait SecretKeyCodec {
+    fn new_random() -> Self;
+    fn from_big_int(n: &BigInt) -> Self;
+
+    fn to_big_int(&self) -> BigInt;
     fn get_q() -> BigInt;
 }
 
-/// Secret Key Codec: BigInt <> SecretKey
-pub trait SecretKeyCodec<EC> {
-    fn new_random(s: &EC) -> Self;
-    fn from_big_int(s: &EC, n: &BigInt) -> Self;
-
-    fn to_big_int(&self) -> BigInt;
-}
-
 /// Public Key Codec: Point <> PublicKey
-pub trait PublicKeyCodec<EC, SK> {
+pub trait PublicKeyCodec {
     const KEY_SIZE: usize;
     const HEADER_MARKER: usize;
 
+    fn get_base_point() -> Point;
     fn bytes_compressed_to_big_int(&self) -> BigInt;
     fn to_point(&self) -> Point;
 
     fn from_key_slice(key: &[u8]) -> Point;
-    fn to_key(s: &EC, p: &Point) -> Self;
+    fn to_key(p: &Point) -> Self;
     fn to_key_slice(p: &Point) -> Vec<u8>;
 }


### PR DESCRIPTION
_Please do not merge in master, this introduce a backward incompatible change. I will take care of merging it at the same time as the change in multi-party-ecdsa._

This change remove context exposure for utility functions. From @apoelstra:

> If you are using the latest version of the library, 0.10.0 you can use `Secp256k1::without_caps()` and the type system will make sure that you only access functions that work without capabilities. I just realized I need to update all the docs for this.
> 
> But if you just use `Secp256k1::new()` this will create a context for both signing and verification, building two precomputation tables that take over 10 milliseconds. This is roughly 200 times as long as signature verification and over a million times as long as deserializing a public key. Do not do this!

cc/ @apoelstra